### PR TITLE
fix: reply to the interaction has already been sent or deferred

### DIFF
--- a/.changeset/sour-carrots-decide.md
+++ b/.changeset/sour-carrots-decide.md
@@ -1,0 +1,5 @@
+---
+'thinc-discord-bot': patch
+---
+
+Fix reply to the interaction has already been sent or deferred during confirmRegistration

--- a/src/discord/commands/register/register.collector.ts
+++ b/src/discord/commands/register/register.collector.ts
@@ -77,6 +77,9 @@ export class PostInteractionCollector {
         .setNickname(`${generationName} - ${nickname}`)
     }
 
+    // Temporary fix for the issue 'The reply to this interaction has already been sent or deferred.'
+    if (interaction.replied) return
+
     // update and reply result to user
     await interaction.update({
       content: 'ลงทะเบียนเสร็จสิ้น! อย่าลืม dismiss ข้อความนี้นะ',


### PR DESCRIPTION
There were multiple occurrences of this issue

```
Error [InteractionAlreadyReplied]: The reply to this interaction has already been sent or deferred.
    at ButtonInteraction.update (/Users/thana/development/thinc-discord-bot/node_modules/.pnpm/discord.js@14.11.0/node_modules/discord.js/src/structures/interfaces/InteractionResponses.js:225:46)
    at PostInteractionCollector.confirmRegistration (/Users/thana/development/thinc-discord-bot/src/discord/commands/register/register.collector.ts:81:23)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at PostInteractionCollector.onCollect (/Users/thana/development/thinc-discord-bot/src/discord/commands/register/register.collector.ts:26:7)
``` 

It seems that `confirmRegistration` is ran twice for each user confirmation. With the following code in discord.js, `await interaction.update` throws an error on the second run.
```
if (this.deferred || this.replied) throw new DiscordjsError(ErrorCodes.InteractionAlreadyReplied);
```

I am unfamiliar with discord.js and Discord API in general to determine why it run twice. 

This PR applies temporary fix for the issue. Expected registration flow is still runnable.